### PR TITLE
HOCS-4340: add build drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,35 @@
+---
+kind: pipeline
+type: kubernetes
+name: build
+
+trigger:
+  event:
+    - push
+
+steps:
+  - name: build project
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.11_9-2
+    commands:
+      - ./gradlew assemble --no-daemon
+
+  - name: test project
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.11_9-2
+    commands:
+      - ./gradlew check --no-daemon
+    depends_on:
+      - build project
+
+  - name: build & push
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-bulk-case-action
+      tags:
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project


### PR DESCRIPTION
This change adds an initial build and push pipeline. This builds the 
java project, runs the tests and then creates and pushes the 
resultant image to Quay.