### PR TITLE
Add 60-minute job timeout

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -13,6 +13,6 @@ export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffic
 
 cd kd
 
-kd -f hocs-bulk-case-action.yaml
+kd --timeout 60m -f hocs-bulk-case-action.yaml
 kd run wait --for=condition=complete "job/hocs-bulk-case-action"
 kd --delete -f hocs-bulk-case-action.yaml


### PR DESCRIPTION
The default timeout set by kd is 3 minutes, to support the bulk updating
this changes ups this to 60-minutes. This falls in line with the drone
pipeline timeout that is unchangeable at 60 minutes. This will allow
500 cases to be bulk closed at once as (500 * 5) / 60 = around 41
minutes.